### PR TITLE
#160617666 Document API endpoints using swagger and coreapi

### DIFF
--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -4,7 +4,9 @@ from .views import (
     LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView
 )
 
+
 app_name='authentication'
+
 urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view()),
     path('users/', RegistrationAPIView.as_view()),

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -11,6 +11,11 @@ from .serializers import (
 
 
 class RegistrationAPIView(APIView):
+
+    """
+    post:
+    Register a user to the platform.
+    """
     # Allow any user (authenticated or not) to hit this endpoint.
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
@@ -30,6 +35,12 @@ class RegistrationAPIView(APIView):
 
 
 class LoginAPIView(APIView):
+
+    """
+    post:
+    Login a registered user.
+    """
+
     permission_classes = (AllowAny,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = LoginSerializer
@@ -48,6 +59,13 @@ class LoginAPIView(APIView):
 
 
 class UserRetrieveUpdateAPIView(RetrieveUpdateAPIView):
+    """
+    retrieve:
+    fetch a user's details.
+    update:
+    Modify a user's details.
+
+    """
     permission_classes = (IsAuthenticated,)
     renderer_classes = (UserJSONRenderer,)
     serializer_class = UserSerializer

--- a/authors/settings/defaults.py
+++ b/authors/settings/defaults.py
@@ -43,6 +43,7 @@ INSTALLED_APPS = [
     'authors.apps.authentication',
     'authors.apps.core',
     'authors.apps.profiles',
+    'rest_framework_swagger',
 ]
 
 MIDDLEWARE = [
@@ -145,4 +146,5 @@ REST_FRAMEWORK = {
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'authors.apps.authentication.backends.JWTAuthentication',
     ),
+    
 }

--- a/authors/urls.py
+++ b/authors/urls.py
@@ -15,10 +15,17 @@ Including another URLconf
 """
 from django.urls import include,path
 from django.contrib import admin
+from rest_framework.documentation import include_docs_urls
+from rest_framework_swagger.views import get_swagger_view
+
+schema_view = get_swagger_view(title="Authors Haven API ")
 
 urlpatterns = [
     path('admin/', admin.site.urls),
 
     path('api/', include('authors.apps.authentication.urls', namespace='authentication')),
+    path('swagger-docs/', schema_view),
+    path('coreapi-docs/', include_docs_urls(title='Authors Haven API')),
+    
 ]
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,5 @@ psycopg2-binary==2.7.5
 gunicorn==19.9.0
 django-heroku==0.3.1
 dj-database-url==0.5.0
+django-rest-swagger==2.2.0
+coreapi==2.3.3


### PR DESCRIPTION
#### What does this PR do?
- Documentation of API endpoints using swagger and core api

#### Description of Task to be completed?
- Make sure the following endpoints are documented:

`POST /api/user/signup`
`POST /api/user/login`

#### How should this be manually tested?
- install the required packages

`pip install django-rest-swagger==2.2.0`
`pip install coreapi==2.3.3`

- start django server by running  - python manage.py runserver
- visit `localhost:8000/swagger-docs` to view swagger documentation
- visit `localhost:8000/coreapi-docs` to view coreapi documentation

#### What are the relevant pivotal tracker stories?
[#160617666] (https://www.pivotaltracker.com/story/show/160617666)
