### PR TITLE
#160617670 add functionality to reset password via email

### DIFF
--- a/app.json
+++ b/app.json
@@ -1,4 +1,4 @@
-{
+  {
     "name": "ah-backend-lannister",
     "scripts": {},
     "env": {
@@ -43,6 +43,9 @@
       },
       "EMAIL_PORT":{
         "required": true
+      },
+      "SENDGRID_API_KEY": {
+        "required": true
       }
     },
     "formation": {
@@ -59,3 +62,4 @@
       }
     ]
   }
+

--- a/authors/apps/authentication/send_email.py
+++ b/authors/apps/authentication/send_email.py
@@ -1,0 +1,24 @@
+import os
+import ssl
+
+import sendgrid
+from decouple import Csv, config
+from sendgrid.helpers.mail import *
+
+ssl._create_default_https_context = ssl._create_unverified_context
+
+
+def send_gridmail(data, token, url):
+    sg = sendgrid.SendGridAPIClient(apikey=config('SENDGRID_API_KEY'))
+    from_email = Email("support@ah-haven.com")
+    to_email = Email(data)
+    subject = 'Password reset Email- AH-Haven'
+    content = Content("text/plain", f"You receiving this email because\
+                      you need password reset on\
+                      Authors haven.\
+                      Click the link to reset your password \
+                      http://{url}/api/users/password_reset/confirm/{token}/ \
+                    DONT share this link with anyone")
+    mail = Mail(from_email, subject, to_email, content)
+    response = sg.client.mail.send.post(request_body=mail.get())
+    return ({'message': f'a reset link has been sent to your email {data}'})

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -1,7 +1,10 @@
 import re
 
+import jwt
 from django.contrib.auth import authenticate
+from django.shortcuts import get_object_or_404
 from rest_framework import serializers
+
 from .models import User
 
 
@@ -182,3 +185,29 @@ class UserSerializer(serializers.ModelSerializer):
         instance.save()
 
         return instance
+
+
+
+class PasswordResetSerializer(serializers.Serializer):
+    email = serializers.EmailField(required=False)
+    message = serializers.EmailField(max_length=255, required=False)
+    token = serializers.EmailField(max_length=255, required=False)
+
+    class Meta:
+        model = User
+        fields = ('token')
+
+    def validate(self, data):
+        email = data.get('email', None)
+        if email is None:
+            raise serializers.ValidationError(
+                'An email is required to reset password.'
+            )
+        user = get_object_or_404(User, email=email)
+        # user.is_active=False
+        
+        # return token here
+        return {
+            'email': user,
+            'token':user.token(0.0208333),
+        }

--- a/authors/apps/authentication/urls.py
+++ b/authors/apps/authentication/urls.py
@@ -1,15 +1,20 @@
 from django.urls import path
 
-from .views import (
-    LoginAPIView, RegistrationAPIView, UserRetrieveUpdateAPIView, UserAccountVerifyView
-)
+from .views import (LoginAPIView, RegistrationAPIView, UpdatePassword,
+                    UserAccountVerifyView, UserPasswordReset,
+                    UserRetrieveUpdateAPIView)
 
-app_name='authentication'
+app_name = 'authentication'
 
 urlpatterns = [
     path('user/', UserRetrieveUpdateAPIView.as_view()),
     path('users/', RegistrationAPIView.as_view()),
     path('users/login/', LoginAPIView.as_view()),
     path('users/verify_account/<token>/',
-        UserAccountVerifyView.as_view(), name='verify_account'),
+         UserAccountVerifyView.as_view(), name='verify_account'),
+    path('users/password_reset', UserPasswordReset.as_view()),
+    path('users/password_reset/confirm/<str:token>/',
+         UserPasswordReset.as_view()),
+    path('users/password_reset/change/', UpdatePassword.as_view()),
+
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ django-heroku==0.3.1
 dj-database-url==0.5.0
 django-rest-swagger==2.2.0
 coreapi==2.3.3
+sendgrid==5.6.0

--- a/tests/test_authentication/test_base.py
+++ b/tests/test_authentication/test_base.py
@@ -51,3 +51,9 @@ class BaseTest:
                 "password": self.password
             }
         }
+
+        self.user_password_reset_data = {
+            'user': {
+                'password': self.password,
+            }
+        }

--- a/tests/test_authentication/test_password_reset.py
+++ b/tests/test_authentication/test_password_reset.py
@@ -1,0 +1,84 @@
+from django.shortcuts import get_object_or_404
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from authors.apps.authentication.models import User
+
+from .test_base import BaseTest
+from .test_retrieve_update import UpdateUser
+
+
+class PasswordRestTestCase(APITestCase, BaseTest):
+    """This class is a definition of tests for testing password reset using email"""
+
+    def setUp(self):
+        BaseTest.__init__(self)
+        self.client = APIClient()
+        self.email = 'kimbsimon2@gmail.com'
+        # Create a user
+        self.user = User.objects.create_user(
+            self.username, self.email, self.password)
+
+    def password_reset_request(self, email):
+        # Test user email
+        self.user_email = {
+            'user': {
+                'email': email
+            }
+        }
+        self.response = self.client.post('/api/users/password_reset',
+                                         data=self.user_email, format='json')
+        return self.response
+
+    def reset_password(self, password, email):
+        # here get token from the email sent
+        user = get_object_or_404(User, email=email)
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + str(user.token(0.0208333)))
+        self.response = self.client.put(
+            '/api/users/password_reset/change/', self.user_password_reset_data, format='json')
+        return self.response
+
+    def test_initiating_password_reset(self):
+        """Test if email is sent when user initiates password reset"""
+        response = self.password_reset_request(self.email)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_initiating_password_reset_with_invalid_user(self):
+        """Test unregistered email trying to reset password"""
+        email = 'unknown@andela.com'
+        response = self.password_reset_request(email)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_sending_empty_email_for_reset(self):
+        """ Test sending password reset request with empty email"""
+        email = ''
+        response = self.password_reset_request(email)
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_resetting_password(self):
+        """Test correct resetting of password"""
+        response = self.reset_password(self.password, self.email)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_unauthorised_user_clicking_on_reset_link(self):
+        response = self.client.put(
+            '/api/users/password_reset/change/', self.user_password_reset_data, format='json')
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_token_is_returned_when_email_is_clicked(self):
+        user = get_object_or_404(User, email=self.email)
+        token = str(user.token(0.0208333))
+        response = self.client.get(
+            f'/api/users/password_reset/confirm/{token}/', format='json')
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_password_has_been_updated(self):
+        response = self.reset_password(self.password, self.email)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_request_password_reset_with_to_email_field(self):
+        self.response = self.client.post(
+            '/api/users/password_reset', format='json')
+        self.assertEqual(self.response.status_code, status.HTTP_400_BAD_REQUEST)
+    

--- a/tests/test_authentication/test_registration.py
+++ b/tests/test_authentication/test_registration.py
@@ -1,5 +1,7 @@
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
+from authors.apps.authentication.models import User
+
 
 from authors.apps.authentication.models import User
 


### PR DESCRIPTION
### What does this PR do?
- Implement the feature to update user password using an email
#### Description of Task to be completed?
- When a user forgets their password, they enter their email address 
- An email is sent to them with a reset link
- The reset link provides them with a token and URL.
- Then they are allowed to change password.
#### How should this be manually tested?
- Use the  route ending `api/users/password_reset` to send email data in the format `'user': {
                'email': email
            }`
- Use the link send to the email for details
#### Screenshots
- Send email url

<img width="779" alt="send email" src="https://user-images.githubusercontent.com/39520700/46438080-a2b20480-c765-11e8-99a8-1e38011ec61c.png">

- Link sent to email

<img width="1065" alt="email link" src="https://user-images.githubusercontent.com/39520700/46438081-a34a9b00-c765-11e8-83fe-18a2407ce0a2.png">

- Response from email link

<img width="1009" alt="token return" src="https://user-images.githubusercontent.com/39520700/46438083-a34a9b00-c765-11e8-99c9-96809d8d3498.png">

- Token added to header on reset path

<img width="766" alt="header" src="https://user-images.githubusercontent.com/39520700/46438085-a3e33180-c765-11e8-9b39-4d68fcdac316.png">

- Password succefully changed

<img width="776" alt="rest" src="https://user-images.githubusercontent.com/39520700/46438088-a47bc800-c765-11e8-9625-77d9b2956693.png">

#### What are the relevant pivotal tracker stories?
- #160617670
