### PR TITLE
#160617668 add descriptive error messages on user  login/registration 

### DIFF
--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -1,7 +1,7 @@
+import re
+
 from django.contrib.auth import authenticate
-
 from rest_framework import serializers
-
 from .models import User
 
 
@@ -24,6 +24,35 @@ class RegistrationSerializer(serializers.ModelSerializer):
         # List all of the fields that could possibly be included in a request
         # or response, including fields specified explicitly above.
         fields = ['email', 'username', 'password', 'token']
+
+    def validate(self, data):
+        # The `validate` method is where we make sure that the current
+        # instance of `LoginSerializer` has "valid". In the case of logging a
+        # user in, this means validating that they've provided an email
+        # and password and that this combination matches one of the users in
+        # our database.
+        username = data.get('username')
+        email = data.get('email', None)
+        password = data.get('password', None)
+
+        # Raise an exception if the username does not have atleast 3 letters
+        if not re.match("(.*[a-zA-Z]){3}", username):
+            raise serializers.ValidationError(
+                {"username": "The username should have atleast 3 letters"}
+            )
+
+        # Raise an exception if the password is not alphanumeric
+        if not re.match("(.*[a-zA-Z])(.*[0-9])", password):
+            raise serializers.ValidationError(
+                {"password": "The password should have have a number and a letter"}
+            )
+
+        return {
+            'email': email,
+            'username': username,
+            'password': password
+
+        }
 
     def create(self, validated_data):
         # Use the `create_user` method we wrote earlier to create a new user.
@@ -69,7 +98,7 @@ class LoginSerializer(serializers.Serializer):
         # `authenticate` will return `None`. Raise an exception in this case.
         if user is None:
             raise serializers.ValidationError(
-                'A user with this email and password was not found.'
+                "wrong password or email"
             )
 
         # Django provides a flag on our `User` model called `is_active`. The

--- a/tests/test_authentication/test_base.py
+++ b/tests/test_authentication/test_base.py
@@ -6,7 +6,7 @@ class BaseTest:
     def __init__(self):
         self.username = "simon"
         self.email = "simon@andela.com"
-        self.password = "12345678"
+        self.password = "simon123"
         self.bio = "I am left handed"
         self.image_url = "https://i.stack.imgur.com/xHWG8.jpg"
         self.reg_data = {
@@ -35,19 +35,5 @@ class BaseTest:
                 "email": self.email,
                 "bio": self.bio,
                 "image": self.image_url
-            }
-        }
-        self.self_no_password_login = {
-            "user": {
-                "username": self.username,
-                "email": self.email,
-                "password": None
-            }
-        }
-        self.no_email_login = {
-            "user": {
-                "username": self.username,
-                "email": None,
-                "password": self.password
             }
         }

--- a/tests/test_authentication/test_login.py
+++ b/tests/test_authentication/test_login.py
@@ -18,3 +18,23 @@ class LoginTest(APITestCase, BaseTest):
         self.assertIn(self.email, str(response.data))
         self.assertIn("token", str(response.data))
 
+    def test_no_password(self):
+        self.user_login['user']['password'] = " "
+        response = self.client.post(
+            '/api/users/login/', self.user_login, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("blank", str(response.data))
+
+    def test_no_email(self):
+        self.user_login['user']['email'] = " "
+        response = self.client.post(
+            '/api/users/login/', self.user_login, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("blank", str(response.data))
+
+    def test_user_does_not_exist(self):
+        self.user_login['user']['email'] = "miriam@gmail.com"
+        response = self.client.post(
+            '/api/users/login/', self.user_login, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("wrong password or email", str(response.data))

--- a/tests/test_authentication/test_registration.py
+++ b/tests/test_authentication/test_registration.py
@@ -54,4 +54,25 @@ class RegistrationTests(APITestCase, BaseTest):
         with self.assertRaises(TypeError):
             self.user = User.objects.create_superuser(None,None,None)
 
-   
+    def test_register_admin_user(self):
+        self.user = User.objects.create_superuser(
+            self.username, self.email, self.password)
+        self.assertIn(str(self.user), str(self.email))
+
+    def test_register_super_user_without_password(self):
+        with self.assertRaises(TypeError):
+            self.user = User.objects.create_superuser(None, None, None)
+
+    def test_password_not_alphanumeric(self):
+        self.reg_data['user']['password'] = "23456890"
+        response = self.client.post(
+            '/api/users/', self.reg_data, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("a number and a letter", str(response.data))
+
+    def test_invalid_username(self):
+        self.reg_data['user']['username'] = "234568#"
+        response = self.client.post(
+            '/api/users/', self.reg_data, format="json")
+        self.assertEqual(response.status_code, 400)
+        self.assertIn("atleast 3 letters", str(response.data))


### PR DESCRIPTION
#### What does this PR do?
- Ensures that a user recieves descriptive error messages on user login and signup
#### Description of Task to be completed?
- When a user logs in or registers  with invalid data, the user should recieve descriptive error messages.
#### How should this be manually tested?
- add invalid data when signing at api/users/login/  or registering at api/users/ in postman
#### Screenshots
<img width="1281" alt="screen shot 2018-10-04 at 10 43 23" src="https://user-images.githubusercontent.com/9887151/46459726-619c0d80-c7c2-11e8-87b0-8f6e1e636479.png">
<img width="1281" alt="screen shot 2018-10-04 at 10 41 21" src="https://user-images.githubusercontent.com/9887151/46459744-6b257580-c7c2-11e8-8671-c43d93e2d0b2.png">
