### PR TITLE
#160887220 customize authors haven admin site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,10 +2,9 @@
 __pycache__/
 *.py[cod]
 *$py.class
-
+.DS_Store
 # C extensions
 *.so
-
 # Distribution / packaging
 migrations/
 .Python
@@ -95,3 +94,4 @@ ENV/
 
 # SQLite3
 db.sqlite3
+migrations

--- a/authors/apps/authentication/admin.py
+++ b/authors/apps/authentication/admin.py
@@ -1,4 +1,4 @@
-from django.contrib import admin
+from authors.apps.default_admin import *
 from authors.apps.authentication.models import User
 
 class UserAdmin(admin.ModelAdmin):

--- a/authors/apps/authentication/serializers.py
+++ b/authors/apps/authentication/serializers.py
@@ -15,7 +15,6 @@ class RegistrationSerializer(serializers.ModelSerializer):
     # characters, and can not be read by the client.
     password = serializers.CharField(
         max_length=128,
-        min_length=8,
         write_only=True
     )
 
@@ -45,9 +44,11 @@ class RegistrationSerializer(serializers.ModelSerializer):
             )
 
         # Raise an exception if the password is not alphanumeric
-        if not re.match("(.*[a-zA-Z])(.*[0-9])", password):
+        if not re.match("(?=.*[a-z])(?=.*[A-Z])"
+                        "(?=.*[0-9])(?=.*[^a-zA-Z0-9])", password) or len(password)<8:
             raise serializers.ValidationError(
-                {"password": "The password should have have a number and a letter"}
+                {"password": "The password should have atleast 8 characters a"
+                "lowwercase,uppercase,number and a special character"}
             )
 
         return {

--- a/authors/apps/authentication/signals.py
+++ b/authors/apps/authentication/signals.py
@@ -9,4 +9,3 @@ def build_profile_on_user_creation(sender, instance, created, **kwargs):
         profile = Profile(user=instance)
         profile.save()
 
-

--- a/authors/apps/default_admin.py
+++ b/authors/apps/default_admin.py
@@ -1,0 +1,3 @@
+from django.contrib import admin
+
+admin.site.site_header = 'Authors Haven Administration Site'

--- a/authors/apps/profiles/views.py
+++ b/authors/apps/profiles/views.py
@@ -46,7 +46,6 @@ class ProfileRetrieveUpdateView(RetrieveUpdateAPIView):
 
         username=self.kwargs["username"]
         if username == request.user.username:
-  
             user_data = request.data.get('profile', {})
             
             serializer_data = {

--- a/tests/test_authentication/test_base.py
+++ b/tests/test_authentication/test_base.py
@@ -6,7 +6,7 @@ class BaseTest:
     def __init__(self):
         self.username = "simon"
         self.email = "simon@andela.com"
-        self.password = "simon123"
+        self.password = "Simon123@"
         self.bio = "I am left handed"
         self.image_url = "https://i.stack.imgur.com/xHWG8.jpg"
         self.reg_data = {

--- a/tests/test_authentication/test_password_reset.py
+++ b/tests/test_authentication/test_password_reset.py
@@ -14,7 +14,7 @@ class PasswordRestTestCase(APITestCase, BaseTest):
     def setUp(self):
         BaseTest.__init__(self)
         self.client = APIClient()
-        self.email = 'kimbsimon2@gmail.com'
+        self.email = 'kimbsimon@gmail.com'
         # Create a user
         self.user = User.objects.create_user(
             self.username, self.email, self.password)

--- a/tests/test_authentication/test_registration.py
+++ b/tests/test_authentication/test_registration.py
@@ -32,7 +32,7 @@ class RegistrationTests(APITestCase, BaseTest):
         response = self.client.post(
             '/api/users/', self.reg_data, format="json")
         self.assertEqual(response.status_code, 400)
-        self.assertIn("8 characters", str(response.data))
+        self.assertIn("lowwercase,uppercase,number and a special character", str(response.data))
 
     def test_missing_email_field(self):
         del self.reg_data['user']['email']
@@ -56,13 +56,6 @@ class RegistrationTests(APITestCase, BaseTest):
     def test_register_super_user_without_password(self):
         with self.assertRaises(TypeError):
             self.user = User.objects.create_superuser(None, None, None)
-
-    def test_password_not_alphanumeric(self):
-        self.reg_data['user']['password'] = "23456890"
-        response = self.client.post(
-            '/api/users/', self.reg_data, format="json")
-        self.assertEqual(response.status_code, 400)
-        self.assertIn("a number and a letter", str(response.data))
 
     def test_invalid_username(self):
         self.reg_data['user']['username'] = "234568#"

--- a/tests/test_profiles/__init__.py
+++ b/tests/test_profiles/__init__.py
@@ -9,7 +9,10 @@ class BaseTest(TestCase):
         self.user_data = {"user": {
             "username": "admin",
             "email": "admin@gmail.com",
-            "password": "admin12345"}
+            "password": "Admin12345@"
+
+            }
+        
         }
 
         self.profile_data = {"profile": {
@@ -38,19 +41,12 @@ class BaseTest(TestCase):
             "first_name": "spiderman",
             "email": "xyz@gmail.com",
             "bio": "",
-            }
+        }
         }
 
+        self.sign_up = self.client.post(
+            "/api/users/", self.user_data, format="json")
 
-
-        
-
-        
-
-
-
-        self.sign_up = self.client.post("/api/users/", self.user_data, format="json")
-        
-        self.client.credentials(HTTP_AUTHORIZATION='Token ' + self.sign_up.data["token"])
-        
+        self.client.credentials(
+            HTTP_AUTHORIZATION='Token ' + self.sign_up.data["token"])
 


### PR DESCRIPTION
#### What does this PR do?
- Customize authors haven admin site
- Modify the password validation 
#### Description of Task to be completed?
- Change admin header from django administration Site to Authors Haven Administration Site
- Modify password validation to ensure that user password has at least a lowercase letter, uppercase letter, number, and a special character
#### How should this be manually tested?
- When you go to  admin/ url  site header should be Authors Haven Administration Site
- To test password validation, go to api/users/ and add a password that doesnot contain lowercase,uppercase,number and a special character. you will recieve an error message
#### What are the relevant pivotal tracker stories?
#160887220
 #160617668
#### Screenshots (if appropriate)

<img width="1055" alt="screen shot 2018-10-07 at 00 24 29" src="https://user-images.githubusercontent.com/9887151/46576016-32a3b880-c9c9-11e8-955e-f6f8fc1ebf0a.png">

<img width="672" alt="screen shot 2018-10-07 at 00 35 55" src="https://user-images.githubusercontent.com/9887151/46576018-3df6e400-c9c9-11e8-91f4-de3770ba4931.png">

<img width="1125" alt="screen shot 2018-10-07 at 00 39 18" src="https://user-images.githubusercontent.com/9887151/46576030-831b1600-c9c9-11e8-8fbb-b84613d08f53.png">
