### PR TITLE
#160617682 pagination support for articles

### DIFF
--- a/authors/apps/articles/views.py
+++ b/authors/apps/articles/views.py
@@ -7,13 +7,12 @@ from authors.apps.articles.renderers import ArticleJSONRenderer
 from authors.apps.articles.serializers import ArticleSerializer
 from rest_framework.exceptions import PermissionDenied
 from .models import Article
-from django.core.paginator import Paginator, EmptyPage, PageNotAnInteger
 from rest_framework import serializers
 from django.core.exceptions import ObjectDoesNotExist
 
 
 class ArticleAPIView(generics.ListCreateAPIView):
-    """create an article, list all articles """
+    """create an article, list all articles paginated to 5 per page"""
     queryset = Article.objects.all()
     permission_classes = (IsAuthenticatedOrReadOnly,)
     renderer_classes = (ArticleJSONRenderer,)
@@ -28,9 +27,9 @@ class ArticleAPIView(generics.ListCreateAPIView):
         return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
     
     def perform_create(self, serializer):
-        serializer.save(author=self.request.user)
+        serializer.save(author=self.request.user)   
 
-        
+
 class ArticleAPIDetailsView(generics.RetrieveUpdateDestroyAPIView):
     """retreive, update and delete an article """
     permission_classes = (IsAuthenticatedOrReadOnly,)

--- a/authors/settings/defaults.py
+++ b/authors/settings/defaults.py
@@ -154,6 +154,8 @@ AUTH_USER_MODEL = 'authentication.User'
 REST_FRAMEWORK = {
     'EXCEPTION_HANDLER': 'authors.apps.core.exceptions.core_exception_handler',
     'NON_FIELD_ERRORS_KEY': 'error',
+    'DEFAULT_PAGINATION_CLASS': 'rest_framework.pagination.PageNumberPagination',
+    'PAGE_SIZE': 5,
 
     'DEFAULT_AUTHENTICATION_CLASSES': (
         'authors.apps.authentication.backends.JWTAuthentication',


### PR DESCRIPTION
#### What does this PR do?
- Enable pagination support for the articles so that reading is not a nightmare for readers when there are so many articles. 
#### Description of Task to be completed?
- When a user wants to views articles, they can view paginated articles
#### How should this be manually tested?
- Viewing all articles by accessing this endpoint at ```/api/articles/``` in postman
#### Screenshots
- view all paginated articles
![image](https://user-images.githubusercontent.com/37612799/46825986-8c2b2f00-cd9d-11e8-8601-f77aa74d66ee.png)

#### What are the relevant pivotal tracker stories?
- #160617682