### PR TITLE
#160617685 users should be able to share articles across different channels

### DIFF
--- a/authors/apps/articles/models.py
+++ b/authors/apps/articles/models.py
@@ -1,17 +1,14 @@
-from authors.apps.authentication.models import User
 from django.conf import settings
 from django.contrib.postgres.fields import ArrayField
 from django.db import models
 from django.db.models import Avg, Count
 from django.utils import timezone
 from django.utils.text import slugify
-
-from .utils import get_unique_slug, time
-
-from django.contrib.postgres.fields import ArrayField
-from authors.apps.authentication.models import User
-from .utils import get_unique_slug, time
 from taggit.managers import TaggableManager
+
+from authors.apps.authentication.models import User
+
+from .utils import get_unique_slug, time
 
 
 class Category(models.Model):

--- a/authors/apps/articles/renderers.py
+++ b/authors/apps/articles/renderers.py
@@ -22,8 +22,14 @@ class RateUserJSONRenderer(AhJSONRenderer):
     charset = 'utf-8'
     object_label = 'rate'
 
+
 class CategoryJSONRenderer(AhJSONRenderer):
     charset = 'utf-8'
     object_label = 'category'
+
+
+class ShareArticleJSONRenderer(AhJSONRenderer):
+    charset = 'utf-8'
+    object_label = 'share'
 
 

--- a/authors/apps/articles/serializers.py
+++ b/authors/apps/articles/serializers.py
@@ -82,3 +82,15 @@ class LikeArticleSerializer(serializers.ModelSerializer):
 
     def get_favorites_count(self, instance):
         return instance.favorited_by.count()
+
+
+class ShareEmailSerializer(serializers.Serializer):
+    email = serializers.EmailField(max_length=255)
+
+    def check(self, data):
+        email = data.get['email', None]
+
+        if email is None:
+            raise serializers.ValidationError(
+                'An email is required to share.'
+            )

--- a/authors/apps/articles/urls.py
+++ b/authors/apps/articles/urls.py
@@ -1,8 +1,11 @@
 from django.urls import path
 
-from .views import (ArticleAPIView, ArticleAPIDetailsView, 
-            RateArticleView, LikeArticleView, LikeAPIDetailsView,
-             TagListAPIView, TagRetrieveAPIView, CategoryListCreateAPIView, CategoryRetrieveAPIView, FavoriteArticleView, UnFavoriteArticleView)
+from .views import (
+    ArticleAPIView, ArticleAPIDetailsView, 
+    RateArticleView, LikeArticleView, LikeAPIDetailsView,
+    TagListAPIView, TagRetrieveAPIView, CategoryListCreateAPIView,
+    CategoryRetrieveAPIView, FavoriteArticleView, UnFavoriteArticleView,
+    ShareArticleAPIView,)
 
 app_name = "articles"
 
@@ -13,13 +16,16 @@ urlpatterns = [
     path('articles/<str:slug>/rating/', RateArticleView.as_view()),
     path('articles/<str:slug>/like/',
          LikeArticleView.as_view(), name='like_article'),
+    path('articles/<str:slug>/share/',
+         ShareArticleAPIView.as_view(), name='share_article'),
     path('articles/<str:slug>/dislike/',
          LikeAPIDetailsView.as_view(), name='dislike'),
     path("tags/", TagListAPIView.as_view()),
     path("tags/<str:tag_name>/", TagRetrieveAPIView.as_view()),
     path("categories/", CategoryListCreateAPIView.as_view()),
     path("categories/<str:cat_name>/", CategoryRetrieveAPIView.as_view()),
-    path('articles/<str:slug>/favorite/',FavoriteArticleView.as_view(), name = "favorite"),
-    path('articles/<str:slug>/unfavorite/',UnFavoriteArticleView.as_view(), name = "unfavorite")
+    path('articles/<str:slug>/favorite/', FavoriteArticleView.as_view(), name="favorite"),
+    path('articles/<str:slug>/unfavorite/', UnFavoriteArticleView.as_view(), name="unfavorite")
+
 
 ]

--- a/tests/test_articles/test_articles.py
+++ b/tests/test_articles/test_articles.py
@@ -119,6 +119,25 @@ class ArticlesTest(APITestCase,BaseTest):
         response = self.client.get('/api/articles/?title={}/'.format(title), 
         format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+    
+    def test_share_article(self):
+        self.create_login_user()
+        article = self.client.post('/api/articles/',self.create_article, 
+        format="json")
+        articleslug = article.data["slug"]
+        response = self.client.post('/api/articles/{}/share/'.format(articleslug), 
+        self.share_article, format="json")
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+    
+    def test_share_wrong_article_slug(self):
+        self.create_login_user()
+        article = self.client.post('/api/articles/',self.create_article, 
+        format="json")
+        articleslug = "j"
+        response = self.client.post('/api/articles/{}/share/'.format(articleslug), 
+        self.share_article, format="json")
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
 
 
 

--- a/tests/test_authentication/test_base.py
+++ b/tests/test_authentication/test_base.py
@@ -152,3 +152,8 @@ class BaseTest:
                 "likes": True,
             }
         }
+        self.share_article = {
+            "share": {
+                "email": self.email
+            }
+        }


### PR DESCRIPTION
#### What does this PR do?
-  A user should be able to share articles; both mine and others via email 
-  A user  can share both their articles and other peoples articles
#### Description of Task to be completed?
- As an authenticated user, I should be able to share articles; both mine and others via email and social media platforms
#### How should this be manually tested?
- sharing the articles by accessing this endpoint at ```/api/articles/{`slug`}/share/``` in postman.

#### Screenshots
- sharing by email
![image](https://user-images.githubusercontent.com/37612799/47154859-27675b80-d2ec-11e8-8a48-4834f152c126.png)

- sharing a non-existing/unpublished article
![image](https://user-images.githubusercontent.com/37612799/47154940-5bdb1780-d2ec-11e8-836e-6b61d03a92f8.png)

#### What are the relevant pivotal tracker stories?
- #160617685