### PR TITLE
Fix password reset feature

### DIFF
--- a/authors/apps/authentication/send_email.py
+++ b/authors/apps/authentication/send_email.py
@@ -4,21 +4,19 @@ import ssl
 import sendgrid
 from decouple import Csv, config
 from sendgrid.helpers.mail import *
+from django.template.loader import render_to_string
 
 ssl._create_default_https_context = ssl._create_unverified_context
 
 
-def send_gridmail(data, token, url):
+def send_gridmail(data,url):
+    message_template = "password_reset.html"
+    message = render_to_string(message_template,{"url":url})
     sg = sendgrid.SendGridAPIClient(apikey=config('SENDGRID_API_KEY'))
     from_email = Email("support@ah-haven.com")
     to_email = Email(data)
     subject = 'Password reset Email- AH-Haven'
-    content = Content("text/plain", f"You receiving this email because\
-                      you need password reset on\
-                      Authors haven.\
-                      Click the link to reset your password \
-                      http://{url}/api/users/password_reset/confirm/{token}/ \
-                    DONT share this link with anyone")
+    content = Content("text/html",message)
     mail = Mail(from_email, subject, to_email, content)
     response = sg.client.mail.send.post(request_body=mail.get())
     return ({'message': f'a reset link has been sent to your email {data}'})

--- a/authors/apps/authentication/views.py
+++ b/authors/apps/authentication/views.py
@@ -150,10 +150,11 @@ class UserPasswordReset(RetrieveUpdateAPIView):
         data_from_serializer.is_valid(raise_exception=True)
 
         # send email method
-        url = request.get_host()
         email = data_from_serializer.data['email']
         token = data_from_serializer.data['token']
-        response = send_gridmail(email, token, url)
+        host='http://'+request.get_host()+'/api/users/password_reset/confirm/'
+        url=user.get('url',host)+token
+        response = send_gridmail(email,url)
         return Response(response, status=status.HTTP_200_OK)
 
     def retrieve(self, request,token, *args, **kwargs):

--- a/authors/apps/notifications/templates/password_reset.html
+++ b/authors/apps/notifications/templates/password_reset.html
@@ -1,0 +1,40 @@
+<table style="background-color: #f2f8f9; max-width:670px;  margin:0 auto;" width="100%" border="0" align="center"
+    cellpadding="0" cellspacing="0">
+    <tbody>
+        <tr>
+            <td style="height:80px;">&nbsp;</td>
+        </tr>
+        <tr>
+            <td style="height:40px;">&nbsp;</td>
+        </tr>
+        <tr>
+            <td>
+                <table width="95%" border="0" align="center" cellpadding="0" cellspacing="0" style="max-width:670px;background:#fff; border-radius:3px; text-align:center;-webkit-box-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.16), 0 1px 3px 0 rgba(0, 0, 0, 0.12);-moz-box-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.16), 0 1px 3px 0 rgba(0, 0, 0, 0.12);box-shadow:0 1px 3px 0 rgba(0, 0, 0, 0.16), 0 1px 3px 0 rgba(0, 0, 0, 0.12)">
+                    <tbody>
+                        <tr>
+                            <td style="height:40px;">&nbsp;</td>
+                        </tr>
+                        <tr>
+                            <td style="padding:0 15px;">
+                                <h1 style="color:#3075BA; font-weight:400; margin:0;font-size:30px;">You have requested
+                                    to reset your password</h1>
+                                <span style="display:inline-block; vertical-align:middle; margin:29px 0 26px; border-bottom:1px solid #cecece; width:100px;"></span>
+                                <p style="color:#171f23de; font-size:15px;line-height:24px; margin:0;">
+                                    Click on the link below to reset your password
+                                </p>
+                                <a href="{{url}}" style="background:#3075BA;text-decoration:none !important; font-weight:500; margin-top:35px; color:#fff;text-transform:uppercase; font-size:14px;padding:10px 12px;display:inline-block;border-radius:3px;">Reset Password</a>
+                            </td>
+                        </tr>
+                        <tr>
+                            <td style="height:40px;">&nbsp;</td>
+                        </tr>
+                    </tbody>
+                </table>
+            </td>
+        </tr>
+        <tr>
+            <td style="height:20px;">&nbsp;</td>
+            <td style="height:80px;">&nbsp;</td>
+        </tr>
+    </tbody>
+</table>

--- a/authors/settings/defaults.py
+++ b/authors/settings/defaults.py
@@ -83,9 +83,9 @@ INSTALLED_APPS = [
 
 
 MIDDLEWARE = [
+    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.security.SecurityMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
-    'corsheaders.middleware.CorsMiddleware',
     'django.middleware.common.CommonMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
@@ -174,6 +174,8 @@ CORS_ORIGIN_WHITELIST = (
     '0.0.0.0:4000',
     'localhost:4000',
 )
+
+CORS_ORIGIN_ALLOW_ALL = True
 
 # Tell Django about the custom `User` model we created. The string
 # `authentication.User` tells Django we are referring to the `User` model in


### PR DESCRIPTION
#### What does this PR do
- make changes to the data returned at password reset
- add CORS settings to the backend

#### How can this be manually tested
- send a post request to the URL `/api/users/password_reset` with the data
```
{
  "user":{
    "email": "kimbsimon2@gmail.com",
    "url": "FRONT_END_URL"
    
  }
}
```
- an email is sent to the email with a link to the frontend
- if a URL is not provided, the API URL is used
#### Screenshots
<img width="781" alt="screen shot 2018-11-06 at 12 59 09" src="https://user-images.githubusercontent.com/39520700/48056890-c8e31e00-e1c3-11e8-931d-e5ec6635f064.png">

